### PR TITLE
fix for windows for CT FFI

### DIFF
--- a/gcc/closures.c
+++ b/gcc/closures.c
@@ -108,7 +108,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #ifndef _MSC_VER
-#include <unistd.h>
+//#include <unistd.h>
 #endif
 #include <string.h>
 #include <stdio.h>

--- a/libffi.nim
+++ b/libffi.nim
@@ -10,8 +10,14 @@
 {.deadCodeElim: on.}
 
 when defined(windows):
+  import os
   # on Windows we don't use a DLL but instead embed libffi directly:
-  {.pragma: mylib, header: r"ffi.h".}
+
+  const thisPath = currentSourcePath.parentDir
+  const flag = "-I" & (thisPath / "common") & " -I" & thisPath
+  {.passC: flag.}
+
+  {.pragma: mylib, header: r"common/ffi.h".}
 
   #{.compile: r"common\malloc_closure.c".}
   {.compile: r"common\raw_api.c".}

--- a/libffi.nimble
+++ b/libffi.nimble
@@ -4,5 +4,8 @@ author        = "Andreas Rumpf"
 description   = "libffi wrapper for Nim."
 license       = "MIT"
 
+when defined(windows):
+  installExt     = @["nim", "c", "h", "s"]
+
 # Dependencies
 requires "nim >= 0.10.0"

--- a/libffi.nimble
+++ b/libffi.nimble
@@ -1,9 +1,8 @@
-[Package]
-name          = "libffi"
-version       = "1.0.0"
+# Package
+version       = "1.0.1"
 author        = "Andreas Rumpf"
 description   = "libffi wrapper for Nim."
 license       = "MIT"
 
-[Deps]
-Requires: "nim >= 0.10.0"
+# Dependencies
+requires "nim >= 0.10.0"


### PR DESCRIPTION
@Araq I tested this on a windows 10 machine, it makes https://github.com/nim-lang/Nim/pull/10150 (FFI at CT) work (EDIT: with win32 only; win64 still has issues)

after merge, please tag so that `nimble install` will pick it up

