### PR TITLE
Update libffi to work with latest version

### DIFF
--- a/libffi.nim
+++ b/libffi.nim
@@ -80,7 +80,7 @@ type
     size*: int
     alignment*: uint16
     typ*: uint16
-    elements*: ptr ptr Type
+    elements*: ptr UncheckedArray[ptr Type]
 {.deprecated: [TType: Type].}
 
 var
@@ -96,7 +96,7 @@ var
   type_float* {.importc: "ffi_type_float", mylib.}: Type
   type_double* {.importc: "ffi_type_double", mylib.}: Type
   type_pointer* {.importc: "ffi_type_pointer", mylib.}: Type
-  type_longdouble* {.importc: "ffi_type_longdouble", mylib.}: Type
+  type_longdouble* {.importc: "ffi_type_double", mylib.}: Type
 
 type
   Status* {.size: sizeof(cint).} = enum


### PR DESCRIPTION
Libffi made some changes to their dll api. They no longer expose `ffi_type_longdouble`, but instead, offer it in a header like so:

```c
#define ffi_type_longdouble ffi_type_double
```

Also, `elements` is listed as a `ptr ptr` in the `ffi.h` file, but when used, it is apparent that it's supposed to be a pointer to an array of pointers.